### PR TITLE
Fixed possible H(k)<->k(H) confusion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ kpath = ReciprocalPath([
        ], 0.005)
 
 # Solve and plot the problem.
-grH |> kpath |> solve |> plotSolution
+grH(kpath) |> solve |> plotSolution
 ```
 Output:
 
@@ -84,7 +84,7 @@ kpath = ReciprocalPath([
 ], 0.01)
 
 # Solve the problem
-sol = alH |> kpath |> solve
+sol = alH(kpath) |> solve
 
 # Find the Fermi energy (3 free electrons in the unit cell of Al).
 ef = sol |> fermilevel(3)

--- a/examples/pseudopotAl.jl
+++ b/examples/pseudopotAl.jl
@@ -29,7 +29,7 @@ kpath = ReciprocalPath([
 ], 0.01)
 
 # Solve the problem
-sol = alH |> kpath |> solve
+sol = alH(kpath) |> solve
 
 # Find the Fermi energy (3 free electrons in the unit cell of Al).
 ef = sol |> fermilevel(3)

--- a/examples/tbGraphene.jl
+++ b/examples/tbGraphene.jl
@@ -113,4 +113,4 @@ kpath = ReciprocalPath([
        ], 0.005)
 
 # Solve and plot the problem.
-grH |> kpath |> solve |> plotSolution
+grH(kpath) |> solve |> plotSolution

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -8,7 +8,12 @@ abstract type ReciprocalHamiltonian end
 
 function Base.ndims(t::T) where {T <: ReciprocalHamiltonian}
     e = typeof(t)
-    throw(ArgumentError("$e needs to have ndims defined."))
+    throw(ArgumentError("$e needs to have `ndims` defined."))
+end
+
+function getH(t::T) where {T <: ReciprocalHamiltonian}
+    e = typeof(t)
+    throw(ArgumentError("$e needs to have `getH` defined."))
 end
 
 struct ReciprocalBandProblem
@@ -21,7 +26,15 @@ function ReciprocalPath(kpositions::Vector, kstep::Real)
     ReciprocalPath(k.path, k.plength, k.ppoints)
 end
 
+function (h::ReciprocalHamiltonian)(k)
+    getH(h)(k)
+end
+
 function (rp::ReciprocalPath)(h::ReciprocalHamiltonian)
+    ReciprocalBandProblem(h, rp)
+end
+
+function (h::ReciprocalHamiltonian)(rp::ReciprocalPath)
     ReciprocalBandProblem(h, rp)
 end
 

--- a/src/nfe.jl
+++ b/src/nfe.jl
@@ -53,8 +53,12 @@ function PseudoPotentialHamiltonian(V::Matrix, c::Crystal)
     PseudoPotentialHamiltonian(V, n, c)
 end
 
-function (h::PseudoPotentialHamiltonian)(k::Vector)
-    nfH(k, h.n, h.pot, h.c)
+# function (h::PseudoPotentialHamiltonian)(k::Vector)
+#     nfH(k, h.n, h.pot, h.c)
+# end
+
+function getH(h::PseudoPotentialHamiltonian)
+    k -> nfH(k, h.n, h.pot, h.c)
 end
 
 function Base.ndims(t::PseudoPotentialHamiltonian)

--- a/src/tb.jl
+++ b/src/tb.jl
@@ -120,8 +120,12 @@ struct TightBindingHamiltonian <: ReciprocalHamiltonian
     hops::Hoppings
 end
 
-function (p::TightBindingHamiltonian)(k)
-    tbH(k, p.hops)
+# function (p::TightBindingHamiltonian)(k)
+#     tbH(k, p.hops)
+# end
+
+function getH(h::TightBindingHamiltonian)
+    k -> tbH(k, h.hops)
 end
 
 function Base.ndims(t::TightBindingHamiltonian)


### PR DESCRIPTION
Currently the convenient one-liner solution of band problems goes like `hamiltonian |> kpath |> solve...`. This makes sense if you consider how you define the problem - the Hamiltonian is generically useful in many places, while the underlying `ReciprocalBandProblem` is determined by the `ReciprocalPath`.

The issue arises when someone who doesn't know the internals, but knows the physical problem, reads that line and comes to the conclusion that we're not diagonalizing a Hamiltonian as a function of momentum H(k) but solving something of the form k(H) that still somehow gives the proper results.

The `BandSolution` requires the hamiltonian and momentum path in no particular order, so both ways to define the `ReciprocalBandProblem` can coexist. Doing both preserves compatibility with previous versions and enables use of the much more understandable `H(kpath) |> solve`, so we can now do both.