### PR TITLE
IBZ reduction and Monkhorst-Pack grids.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,16 +1,19 @@
 name = "SimpleQuantum"
 uuid = "7c07e4e5-e402-48af-840a-a11b8ea3e28c"
 authors = ["Tomas Polakovic <tom.polakovic@gmail.com> and contributors"]
-version = "0.1.0"
+version = "0.2.3"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Match = "7eb4fadd-790c-5f42-8a69-bfa0b872bfbf"
 RangeHelpers = "3a07dd3d-1c52-4395-8858-40c6328157db"
+SplitApplyCombine = "03a91e81-4c3e-53e1-a0a4-9c0c8f19dd66"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]

--- a/examples/tbGrapheneDOS.jl
+++ b/examples/tbGrapheneDOS.jl
@@ -17,8 +17,8 @@ end
 # Define the tight binding Hamiltonian
 grH = TightBindingHamiltonian(grhops)
 
-# Spec up the DOS calculation: Energy in range (-0.5 Ha, 0.5 Ha) with step of 5 mHa and 400x400 grid points.
-grdos = DOS([i * Ha for i ∈ -0.5:0.005:0.5], 400)
+# Spec up the DOS calculation: Energy in range (-0.5 Ha, 0.5 Ha) with step of 10 mHa and 151x151 grid points.
+grdos = DOS([i * Ha for i ∈ -0.5:0.01:0.5], 151)
 
 # Solve the problem and plot the DOS.
 grH |> grdos |> solve |> plotSolution

--- a/src/SimpleQuantum.jl
+++ b/src/SimpleQuantum.jl
@@ -4,10 +4,12 @@ using LinearAlgebra
 using Unitful
 import Unitful: Å, eV
 using RangeHelpers: range, around
-using Match
+using StaticArrays
+using SplitApplyCombine
 using Colors
 using GLMakie
 using Accessors
+using Combinatorics
 
 include("crystal.jl")
 include("interface.jl")
@@ -20,27 +22,13 @@ include("misc.jl")
 a₀ = 1.889726125Å
 Ha = 27.2eV
 
-export a₀,
-    Ha,
-    Å,
-    eV,
-    Lattice,
-    UnitCell,
-    Crystal,
-    plotcrystal!,
-    fermilevel,
-    shiftenergy,
-    evals,
-    evecs,
-    kvecs,
-    solve,
-    ReciprocalPath,
-    plotSolution,
-    DOS,
-    Hoppings,
-    addhop!,
-    addonsite!,
-    addoverlap!,
-    TightBindingHamiltonian,
-    PseudoPotentialHamiltonian
+export a₀, Ha, Å, eV
+export Lattice, UnitCell, Crystal
+export shiftenergy, fermilevel
+export plotcrystal!
+export evals, evecs, kvecs
+export solve, plotSolution
+export ReciprocalPath, DOS
+export Hoppings, addhop!, addonsite!, addoverlap!
+export TightBindingHamiltonian, PseudoPotentialHamiltonian
 end

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -47,6 +47,29 @@ function dedup_floats(itr)
     out
 end
 
+function approxunique(itr; kwargs...)
+    out = Vector{eltype(itr)}()
+    push!(out, itr[1])
+    for itrel ∈ itr
+        if map(x -> !isapprox(itrel, x; kwargs...), out) |> all
+            push!(out, itrel)
+        end
+    end
+    out
+end
+
+"""
+    isapproxin(el, itr; kwargs)
+
+Determines whether `el` is in iterable collection `itr` as determined by `isapprox`.
+"""
+function isapproxin(el, itr; kwargs...)
+    for i ∈ itr
+        isapprox(el, i; kwargs...) && return true
+    end
+    false
+end
+
 """
     unique_neighbors(c::Crystal)
 

--- a/src/nfe.jl
+++ b/src/nfe.jl
@@ -21,6 +21,8 @@ struct PseudoPotentialHamiltonian <: ReciprocalHamiltonian
     c::Crystal
 end
 
+# interface
+
 """
      PsuedoPotentialHamiltonian(n::Integer, V::Function, c::Crystal)
 
@@ -56,6 +58,8 @@ end
 # function (h::PseudoPotentialHamiltonian)(k::Vector)
 #     nfH(k, h.n, h.pot, h.c)
 # end
+
+crystal(h::PseudoPotentialHamiltonian) = h.c
 
 function getH(h::PseudoPotentialHamiltonian)
     k -> nfH(k, h.n, h.pot, h.c)

--- a/src/tb.jl
+++ b/src/tb.jl
@@ -2,7 +2,7 @@ struct Hop
     γ::Number
     i::Int
     j::Int
-    offset::Union{<:Real, Array{<:Real}}
+    offset::Union{<:Real, AbstractArray{<:Real}}
 end
 
 struct Onsite
@@ -14,7 +14,7 @@ struct Overlap
     S::Number
     i::Int
     j::Int
-    offset::Union{<:Real, Array{<:Real}}
+    offset::Union{<:Real, AbstractArray{<:Real}}
 end
 
 """
@@ -24,9 +24,9 @@ Create an empty hopping list based on crystal structure `c`.
 """
 mutable struct Hoppings
     c::Crystal
-    γs::Array{Hop}
-    μs::Array{Onsite}
-    Ss::Array{Overlap}
+    γs::AbstractArray{Hop}
+    μs::AbstractArray{Onsite}
+    Ss::AbstractArray{Overlap}
     maxij::Int
 
     function Hoppings(c::Crystal)
@@ -81,8 +81,8 @@ end
 
 function tbH(k, hops::Hoppings)
     n = hops.maxij
-    ham = zeros(Complex,n,n)
-    Smat = zeros(ComplexF64,n,n)
+    ham = zeros(ComplexF32,n,n)
+    Smat = zeros(ComplexF32,n,n)
 
     for hop ∈ hops.γs
         i, j = hop.i, hop.j
@@ -105,6 +105,8 @@ function tbH(k, hops::Hoppings)
         Smat[j,i] += conj(S)
     end
     Smat += diagm(ones(n))
+    ham = Hermitian(ham)
+    Smat = Hermitian(Smat)
     (ham, Smat)
 end
 
@@ -119,6 +121,8 @@ Can be called on a vector in k-space to output the Hamiltonian.
 struct TightBindingHamiltonian <: ReciprocalHamiltonian
     hops::Hoppings
 end
+
+crystal(h::TightBindingHamiltonian) = h.hops.c
 
 # function (p::TightBindingHamiltonian)(k)
 #     tbH(k, p.hops)


### PR DESCRIPTION
Brillouin zone evaluation should now be faster (at least for repeated calls).

Removed dependency on `SymmetryReduceBZ.jl`, which was being a bit too slow and unwieldy.